### PR TITLE
feat: Add Person record with demographics fields

### DIFF
--- a/src/main/java/org/zph/claude_test/controller/PersonController.java
+++ b/src/main/java/org/zph/claude_test/controller/PersonController.java
@@ -1,0 +1,78 @@
+package org.zph.claude_test.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.zph.claude_test.model.Person;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+@RestController
+@RequestMapping("/persons")
+public class PersonController {
+
+    private final List<Person> persons = new ArrayList<>();
+    private final AtomicLong idCounter = new AtomicLong(1);
+
+    @GetMapping
+    public List<Person> getAllPersons() {
+        return persons;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Person> getPersonById(@PathVariable Long id) {
+        return persons.stream()
+                .filter(p -> p.id().equals(id))
+                .findFirst()
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public Person createPerson(@RequestBody Person person) {
+        Person created = new Person(
+                idCounter.getAndIncrement(),
+                person.firstName(),
+                person.lastName(),
+                person.email(),
+                person.phoneNumber(),
+                person.address(),
+                person.city(),
+                person.state(),
+                person.zipCode(),
+                person.country()
+        );
+        persons.add(created);
+        return created;
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Person> updatePerson(@PathVariable Long id, @RequestBody Person person) {
+        for (int i = 0; i < persons.size(); i++) {
+            if (persons.get(i).id().equals(id)) {
+                Person updated = new Person(
+                        id,
+                        person.firstName(),
+                        person.lastName(),
+                        person.email(),
+                        person.phoneNumber(),
+                        person.address(),
+                        person.city(),
+                        person.state(),
+                        person.zipCode(),
+                        person.country()
+                );
+                persons.set(i, updated);
+                return ResponseEntity.ok(updated);
+            }
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePerson(@PathVariable Long id) {
+        boolean removed = persons.removeIf(p -> p.id().equals(id));
+        return removed ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/org/zph/claude_test/model/Person.java
+++ b/src/main/java/org/zph/claude_test/model/Person.java
@@ -1,0 +1,14 @@
+package org.zph.claude_test.model;
+
+public record Person(
+        Long id,
+        String firstName,
+        String lastName,
+        String email,
+        String phoneNumber,
+        String address,
+        String city,
+        String state,
+        String zipCode,
+        String country
+) {}


### PR DESCRIPTION
Adds a Person Java record with demographics columns: address, city, state, zip code, country, plus name, email, and phone. Includes a full CRUD REST controller at /persons.

Closes #4

Generated with [Claude Code](https://claude.ai/code)